### PR TITLE
Fix three crawler failure modes that hang or leak the crawl.

### DIFF
--- a/src/pyrefdev/indexer/crawl_docs.py
+++ b/src/pyrefdev/indexer/crawl_docs.py
@@ -140,7 +140,8 @@ class _Crawler:
         self._retry_http_404 = retry_http_404
 
         self._seen_urls: set[str] = set()
-        self._to_crawl_queue: queue.Queue[str] = queue.Queue()
+        # None is the sentinel that tells a worker thread to exit.
+        self._to_crawl_queue: queue.Queue[str | None] = queue.Queue()
         self._crawled_url_to_files: dict[str, Path] = {}
         self._lock = threading.RLock()
 
@@ -165,7 +166,14 @@ class _Crawler:
                 )
                 thread.start()
                 threads.append(thread)
-            self._to_crawl_queue.join()
+            try:
+                self._to_crawl_queue.join()
+            finally:
+                # Otherwise every package leaks num_threads blocked workers.
+                for _ in threads:
+                    self._to_crawl_queue.put(None)
+                for thread in threads:
+                    thread.join()
             self._progress.update(task, visible=False)
 
         else:
@@ -229,8 +237,16 @@ class _Crawler:
     def _crawl_thread(self, task: TaskID) -> None:
         while True:
             url = self._to_crawl_queue.get()
+            if url is None:
+                self._to_crawl_queue.task_done()
+                return
+            saved = None
             try:
                 saved = self._crawl_url(url)
+            except Exception as e:
+                # An escaping exception would skip task_done() and hang crawl.
+                console.warning(f"Failed to crawl url {url}, error: {e}")
+                self._failed_urls[url] = ""
             finally:
                 kwargs: dict[str, Any] = {}
                 if saved is not None:

--- a/src/pyrefdev/indexer/index.py
+++ b/src/pyrefdev/indexer/index.py
@@ -17,7 +17,7 @@ from pyrefdev.config import Package, console
 
 
 _RTD_URL_PATTERN = re.compile(r"https?://([^\s/]+\.readthedocs\.io)\b")
-_MAX_BACKOFF_SECONDS = 86400  # 24 hours
+_BACKOFF_SECONDS = [1, 2, 5, 15, 30, 60, 120, 300, 600, 1800, 3600]
 
 
 def urlopen(url: str):
@@ -26,44 +26,34 @@ def urlopen(url: str):
         method="GET",
         headers={"User-Agent": f"pyrefdev/{__version__} (+https://pyref.dev)"},
     )
-    backoffs = [1, 2, 5, 15, 30, 60, 120, 300, 600, 1800, 3600]
+    backoffs = list(_BACKOFF_SECONDS)
     attempt = 0
 
     while True:
         try:
             return request.urlopen(req, timeout=60)
         except error.HTTPError as e:
-            if e.code == 429:  # Too Many Requests
-                attempt += 1
-                if backoffs:
-                    backoff = backoffs.pop(0) * (0.9 + random.random() / 5.0)
-                else:
-                    backoff = _MAX_BACKOFF_SECONDS * (0.9 + random.random() / 5.0)
-
-                console.warning(
-                    f"HTTP 429 (Too Many Requests) for {url}. "
-                    f"Retrying in {backoff:.1f}s (attempt {attempt})..."
-                )
-                time.sleep(backoff)
-            else:
+            if e.code != 429:  # Too Many Requests
                 raise
+            last_error = e
+            reason = "HTTP 429 (Too Many Requests)"
         except (TimeoutError, error.URLError) as e:
             if isinstance(e, error.URLError) and not isinstance(
                 e.reason, (TimeoutError, OSError)
             ):
                 raise
+            last_error = e
+            reason = "Timeout/Network error"
 
-            attempt += 1
-            if backoffs:
-                backoff = backoffs.pop(0) * (0.9 + random.random() / 5.0)
-            else:
-                backoff = _MAX_BACKOFF_SECONDS * (0.9 + random.random() / 5.0)
-
-            console.warning(
-                f"Timeout/Network error for {url}. "
-                f"Retrying in {backoff:.1f}s (attempt {attempt})..."
-            )
-            time.sleep(backoff)
+        attempt += 1
+        if not backoffs:
+            console.warning(f"{reason} for {url}. Giving up after {attempt} attempts.")
+            raise last_error
+        backoff = backoffs.pop(0) * (0.9 + random.random() / 5.0)
+        console.warning(
+            f"{reason} for {url}. Retrying in {backoff:.1f}s (attempt {attempt})..."
+        )
+        time.sleep(backoff)
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
1. An exception escaping `_crawl_url` used to propagate out of the `finally`
   block in `_crawl_thread`, so `task_done()` was never called and the worker
   died. Once that happened `_to_crawl_queue.join()` blocked forever and the
   crawl hung. The `finally` block also read `saved` before it was assigned,
   which raised `UnboundLocalError` on the first iteration and, on later
   iterations, recorded the *previous* URL's file path against the current URL.
   `_save()` and `_parse_links()` reach this path for real: `urljoin()` raises
   `ValueError` on a malformed href, and writing a page can raise `OSError`.

   Initialize `saved` to None and catch the exception, recording the URL in
   `failed_urls` so it is retried on the next run.

2. `urlopen()` retried forever, sleeping 24h per attempt once the backoff list
   was exhausted. A docs domain that goes away (DNS failure surfaces as a
   `URLError` wrapping `OSError`) parked a thread indefinitely. Give up once
   the backoffs run out and re-raise, letting the caller record the failure.
   Retry patience is unchanged otherwise.

3. Worker threads looped on `get()` and were never told to stop, so every
   crawled package leaked `num_threads_per_package` threads for the lifetime
   of the process. `update-docs` crawls hundreds of packages in a row. Push a
   None sentinel per worker and join them after the queue drains.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015w1f6VC6qKvkL7YQw4FCLy