### PR TITLE
Stop the crawler from losing work when a package fails.

### DIFF
--- a/src/pyrefdev/indexer/crawl_docs.py
+++ b/src/pyrefdev/indexer/crawl_docs.py
@@ -104,8 +104,13 @@ def crawl_docs(
                     seconds_to_sleep_between_requests,
                     retry_http_404,
                 )
-                crawler.crawl(num_threads=num_threads_per_package)
-                crawler.save_crawl_state(package_version, index)
+                try:
+                    crawler.crawl(num_threads=num_threads_per_package)
+                finally:
+                    # Re-crawling from scratch costs hours at this rate limit.
+                    crawler.save_crawl_state(package_version, index)
+            except Exception as e:
+                console.warning(f"Failed to crawl {pkg.pypi}, error: {e}")
             finally:
                 if task is not None:
                     progress.advance(task)
@@ -174,6 +179,7 @@ class _Crawler:
                     self._to_crawl_queue.put(None)
                 for thread in threads:
                     thread.join()
+                self._record_pending_as_failed()
             self._progress.update(task, visible=False)
 
         else:
@@ -220,6 +226,16 @@ class _Crawler:
                         str(saved.relative_to(self._docs_directory))
                     ] = url
             self._crawl_state.failed_urls = failed_urls
+
+    def _record_pending_as_failed(self) -> None:
+        # An aborted crawl saves state, so unvisited URLs must stay retryable.
+        while True:
+            try:
+                url = self._to_crawl_queue.get_nowait()
+            except queue.Empty:
+                return
+            if url is not None:
+                self._failed_urls.setdefault(url, "")
 
     def save_crawl_state(self, package_version: version.Version, index: Index) -> None:
         if (state := self._crawl_state) is None:
@@ -278,7 +294,13 @@ class _Crawler:
         maybe_redirected_url = f.url
         if maybe_redirected_url != url and not self._should_crawl(maybe_redirected_url):
             return None
-        saved = self._save(maybe_redirected_url, content)
+        try:
+            saved = self._save(maybe_redirected_url, content)
+        except OSError as e:
+            # A URL can exceed NAME_MAX or collide with an existing directory.
+            console.warning(f"Failed to save url {url}, error: {e}")
+            self._failed_urls[url] = ""
+            return None
         return saved, maybe_redirected_url, content
 
     def _crawl_url(self, url: str) -> Path | None:
@@ -303,11 +325,11 @@ class _Crawler:
         if not relative_path.endswith(".html"):
             output = output / "index.html"
         output.parent.mkdir(parents=True, exist_ok=True)
-        if output.exists():
-            existing_content = output.read_text()
-            if content == existing_content:
-                return output
-        output.write_text(content)
+        # Bytes keep this independent of the locale's default encoding.
+        encoded = content.encode("utf-8")
+        if output.exists() and output.read_bytes() == encoded:
+            return output
+        output.write_bytes(encoded)
         return output
 
     def _should_crawl(self, url: str) -> bool:
@@ -329,9 +351,12 @@ class _Crawler:
             href = link.get("href")
             if not isinstance(href, str):
                 continue
-            absolute_href = parse.urljoin(current_url, href)
             # href could be full URL, absolute path, and relative path.
-            parsed_href = parse.urlparse(absolute_href)
+            try:
+                parsed_href = parse.urlparse(parse.urljoin(current_url, href))
+            except ValueError:
+                # A bad IPv6 literal in an href must not abort the page.
+                continue
             # Remove the fragment.
             parsed_href = parsed_href._replace(fragment="")
             links.add(parse.urlunparse(parsed_href))

--- a/src/pyrefdev/indexer/index.py
+++ b/src/pyrefdev/indexer/index.py
@@ -18,6 +18,8 @@ from pyrefdev.config import Package, console
 
 _RTD_URL_PATTERN = re.compile(r"https?://([^\s/]+\.readthedocs\.io)\b")
 _BACKOFF_SECONDS = [1, 2, 5, 15, 30, 60, 120, 300, 600, 1800, 3600]
+# A 5xx surviving a few retries is a broken page, not a transient blip.
+_SERVER_ERROR_BACKOFF_SECONDS = [1, 5, 15]
 
 
 def urlopen(url: str):
@@ -26,30 +28,36 @@ def urlopen(url: str):
         method="GET",
         headers={"User-Agent": f"pyrefdev/{__version__} (+https://pyref.dev)"},
     )
-    backoffs = list(_BACKOFF_SECONDS)
     attempt = 0
 
     while True:
         try:
             return request.urlopen(req, timeout=60)
         except error.HTTPError as e:
-            if e.code != 429:  # Too Many Requests
+            if e.code == 429:  # Too Many Requests
+                backoffs = _BACKOFF_SECONDS
+            elif 500 <= e.code < 600:
+                backoffs = _SERVER_ERROR_BACKOFF_SECONDS
+            else:
                 raise
             last_error = e
-            reason = "HTTP 429 (Too Many Requests)"
+            reason = f"HTTP {e.code} ({e.reason})"
         except (TimeoutError, error.URLError) as e:
             if isinstance(e, error.URLError) and not isinstance(
                 e.reason, (TimeoutError, OSError)
             ):
                 raise
+            backoffs = _BACKOFF_SECONDS
             last_error = e
             reason = "Timeout/Network error"
 
-        attempt += 1
-        if not backoffs:
-            console.warning(f"{reason} for {url}. Giving up after {attempt} attempts.")
+        if attempt >= len(backoffs):
+            console.warning(
+                f"{reason} for {url}. Giving up after {attempt + 1} attempts."
+            )
             raise last_error
-        backoff = backoffs.pop(0) * (0.9 + random.random() / 5.0)
+        backoff = backoffs[attempt] * (0.9 + random.random() / 5.0)
+        attempt += 1
         console.warning(
             f"{reason} for {url}. Retrying in {backoff:.1f}s (attempt {attempt})..."
         )
@@ -120,12 +128,20 @@ class Index:
         crawl_state_file = self.docs_directory / f"{package}.json"
         if not crawl_state_file.exists():
             return None
-        return IndexState.loads(crawl_state_file.read_text())
+        try:
+            return IndexState.loads(crawl_state_file.read_text(encoding="utf-8"))
+        except (ValueError, TypeError) as e:
+            # A truncated or outdated state file should re-crawl, not crash.
+            console.warning(f"Ignoring unreadable crawl state for {package}: {e}")
+            return None
 
     def save_crawl_state(self, package: str, crawl_state: IndexState) -> None:
         self._ensure_directory()
         crawl_state_file = self.docs_directory / f"{package}.json"
-        crawl_state_file.write_text(crawl_state.dumps())
+        # Write atomically so an interrupt cannot truncate the previous state.
+        tmp_file = crawl_state_file.with_suffix(".json.tmp")
+        tmp_file.write_text(crawl_state.dumps(), encoding="utf-8")
+        tmp_file.replace(crawl_state_file)
 
     def fetch_pypi_data(self, package: str, *, refresh: bool) -> bytes:
         pypi_data_file = self.docs_directory / "__pypi__" / f"{package}.json"

--- a/src/pyrefdev/indexer/parse_docs.py
+++ b/src/pyrefdev/indexer/parse_docs.py
@@ -144,7 +144,7 @@ def _parse_package(
         filepath = package_docs / file
         if not filepath.exists():
             filepath = Path(filepath.as_posix().lower())
-        symbols = parser.parse_symbols(filepath.read_text())
+        symbols = parser.parse_symbols(filepath.read_text(encoding="utf-8"))
         module_count = sum(
             1 if fragment.startswith(_MODULE_FRAGMENT_PREFIX) else 0
             for fragment in symbols.values()


### PR DESCRIPTION
Follow-up to #27, which fixed the hangs. These are the failure modes that still abort a package or silently discard hours of crawling.

### One bad package aborted the whole run, and discarded its crawled pages

`crawl_package` had no `except`, so a single failing package aborted `crawl_docs` and `update-docs` stopped visiting the remaining hundreds. Worse, the exception skipped `save_crawl_state`, so every page already fetched for that package was re-crawled from scratch next run — hours at a 5s/request rate limit. Now caught per package, with state saved from a `finally`.

Saving partial state is only safe with one extra step: URLs still queued when the crawl aborted would otherwise be lost, because the state file then reads as complete and the retry path only revisits `failed_urls`. `_record_pending_as_failed` drains the queue into `failed_urls` so the next run picks them up. On the normal path the queue is empty and it is a no-op.

### `_save` and `_parse_links` raised out of the crawl loop

Both are reachable with real input: `urljoin` raises `ValueError` on a malformed href (a bad IPv6 literal), and saving raises `OSError` when a URL exceeds `NAME_MAX` or collides with an existing directory. Now the link is skipped / the URL recorded as failed. This matters beyond #27's per-URL guard: the retry path reaches these through `f.result()`, where that guard does not apply.

### `_save` was locale-dependent

It used `read_text`/`write_text`, decoding UTF-8 content with the locale's encoding — under `LC_ALL=C` that raises. Now compares and writes bytes. `parse_docs` reads the same files, so it reads them as UTF-8 to match.

### 5xx was treated as permanent

429 and network errors were retried but 5xx was not, so a transient 502 discarded a page for good. Now retried on a short ladder (`[1, 5, 15]`) rather than the full one: unlike a rate limit, a 5xx that survives ~20s is a broken page, and the full ladder would spend 1.8h per URL on a site that is down. 4xx still raises immediately.

### Interrupting a save corrupted the state file

`save_crawl_state` truncated the previous state if interrupted mid-write, and `load_crawl_state` then crashed that package on every later run. Now writes via a temp file and renames, and an unreadable state degrades to a re-crawl instead of an exception.

## Testing

`pytest` (6 passed), `ruff check`/`format`, and `ty` are clean.

Behaviour was checked against the real classes with mocked I/O, covering: malformed href skipped while good links survive; non-ASCII content round-tripping as UTF-8; unchanged content not rewritten; save `OSError` recorded as failed; unvisited URLs preserved as retryable; `crawl_docs` completing normally when all 600+ packages raise; 503 retried 3x and 403 retried 0x; truncated and unknown-key state files degrading to `None`; atomic save leaving no `.tmp` behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015w1f6VC6qKvkL7YQw4FCLy

---
_Generated by [Claude Code](https://claude.ai/code/session_015w1f6VC6qKvkL7YQw4FCLy)_