### PR TITLE
Make the crawler's shared state and retry pacing correct under threads.

### DIFF
--- a/src/pyrefdev/indexer/crawl_docs.py
+++ b/src/pyrefdev/indexer/crawl_docs.py
@@ -262,35 +262,46 @@ class _Crawler:
             except Exception as e:
                 # An escaping exception would skip task_done() and hang crawl.
                 console.warning(f"Failed to crawl url {url}, error: {e}")
-                self._failed_urls[url] = ""
+                self._record_failure(url, "")
             finally:
-                kwargs: dict[str, Any] = {}
-                if saved is not None:
-                    self._crawled_url_to_files[url] = saved
-                    kwargs["extra"] = str(saved)[-24:]
-                self._progress.update(
-                    task,
-                    total=len(self._seen_urls),
-                    completed=len(self._crawled_url_to_files),
-                    refresh=True,
-                    **kwargs,
-                )
-                self._to_crawl_queue.task_done()
+                # task_done() last would be skipped if the update below raises.
+                try:
+                    kwargs: dict[str, Any] = {}
+                    with self._lock:
+                        if saved is not None:
+                            self._crawled_url_to_files[url] = saved
+                            kwargs["extra"] = str(saved)[-24:]
+                        total = len(self._seen_urls)
+                        completed = len(self._crawled_url_to_files)
+                    self._progress.update(
+                        task,
+                        total=total,
+                        completed=completed,
+                        refresh=True,
+                        **kwargs,
+                    )
+                finally:
+                    self._to_crawl_queue.task_done()
+
+    def _record_failure(self, url: str, error_code: str) -> None:
+        with self._lock:
+            self._failed_urls[url] = error_code
 
     def _fetch_and_save_url(self, url: str) -> tuple[Path, str, str] | None:
         try:
             with urlopen(url) as f:
                 content = f.read().decode("utf-8", "backslashreplace")
-            time.sleep(self._seconds_to_sleep_between_requests)
         except error.HTTPError as e:
-            error_code = _http_error_code(e.code) if hasattr(e, "code") else ""
             console.warning(f"Failed to fetch url {url}, error: {e}")
-            self._failed_urls[url] = error_code
+            self._record_failure(url, _http_error_code(e.code))
             return None
         except Exception as e:
             console.warning(f"Failed to fetch url {url}, error: {e}")
-            self._failed_urls[url] = ""
+            self._record_failure(url, "")
             return None
+        finally:
+            # Failures need pacing too, or a failing host gets hammered.
+            time.sleep(self._seconds_to_sleep_between_requests)
         maybe_redirected_url = f.url
         if maybe_redirected_url != url and not self._should_crawl(maybe_redirected_url):
             return None
@@ -299,7 +310,7 @@ class _Crawler:
         except OSError as e:
             # A URL can exceed NAME_MAX or collide with an existing directory.
             console.warning(f"Failed to save url {url}, error: {e}")
-            self._failed_urls[url] = ""
+            self._record_failure(url, "")
             return None
         return saved, maybe_redirected_url, content
 
@@ -307,9 +318,9 @@ class _Crawler:
         if (result := self._fetch_and_save_url(url)) is None:
             return None
         saved, maybe_redirected_url, content = result
-        self._seen_urls.add(maybe_redirected_url)
         new_links = self._parse_links(maybe_redirected_url, content)
         with self._lock:
+            self._seen_urls.add(maybe_redirected_url)
             for new_link in new_links:
                 if new_link in self._seen_urls:
                     continue

--- a/src/pyrefdev/indexer/index.py
+++ b/src/pyrefdev/indexer/index.py
@@ -1,10 +1,12 @@
 import dataclasses
+import datetime
 import json
 import re
 import random
 import subprocess
 import tempfile
 import time
+from email import utils as email_utils
 from pathlib import Path
 from typing import Literal, overload
 from urllib import error, request
@@ -20,6 +22,24 @@ _RTD_URL_PATTERN = re.compile(r"https?://([^\s/]+\.readthedocs\.io)\b")
 _BACKOFF_SECONDS = [1, 2, 5, 15, 30, 60, 120, 300, 600, 1800, 3600]
 # A 5xx surviving a few retries is a broken page, not a transient blip.
 _SERVER_ERROR_BACKOFF_SECONDS = [1, 5, 15]
+_MAX_RETRY_AFTER_SECONDS = 300
+
+
+def _retry_after_seconds(e: error.HTTPError) -> float | None:
+    """Delay requested by a Retry-After header, which may be seconds or a date."""
+    value = e.headers.get("Retry-After") if e.headers else None
+    if not value:
+        return None
+    if value.strip().isdigit():
+        return float(value)
+    try:
+        retry_at = email_utils.parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=datetime.timezone.utc)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return max((retry_at - now).total_seconds(), 0.0)
 
 
 def urlopen(url: str):
@@ -57,6 +77,11 @@ def urlopen(url: str):
             )
             raise last_error
         backoff = backoffs[attempt] * (0.9 + random.random() / 5.0)
+        if isinstance(last_error, error.HTTPError):
+            retry_after = _retry_after_seconds(last_error)
+            if retry_after is not None:
+                # Obey the server's pacing, but never let it stall the crawl.
+                backoff = min(max(retry_after, backoff), _MAX_RETRY_AFTER_SECONDS)
         attempt += 1
         console.warning(
             f"{reason} for {url}. Retrying in {backoff:.1f}s (attempt {attempt})..."
@@ -163,7 +188,8 @@ class Index:
             data = self.fetch_pypi_data(package.pypi, refresh=True)
             pypi_info = json.loads(data)
             return version.parse(pypi_info["info"]["version"])
-        except error.URLError as e:
+        # URLError is an OSError; InvalidVersion/JSONDecodeError are ValueErrors.
+        except (OSError, ValueError, KeyError, TypeError) as e:
             console.warning(
                 f"Failed to fetch pypi version for {package.pypi}, error: {e}"
             )
@@ -219,6 +245,6 @@ def _fetch_latest_cpython_version() -> version.Version | None:
             if (latest := version.parse(cycle["latest"])) > latest_version:
                 latest_version = latest
         return latest_version
-    except error.URLError as e:
+    except (OSError, ValueError, KeyError, TypeError) as e:
         console.warning(f"Failed to fetch latest CPython version, error: {e}")
         return None


### PR DESCRIPTION
Last of the crawler error-handling pass, after #27 (hangs) and #28 (lost work). None of these abort a run; they corrupt counts, waste requests, or hammer a host that is already failing.

### Shared state was written from every worker, mostly unlocked

`_seen_urls`, `_crawled_url_to_files` and `_failed_urls` are written from every worker thread, but only one of those writes took `self._lock`. The GIL hides this today — but the package ships a `Programming Language :: Python :: Free Threading` classifier, and without the GIL these are real lost-update races on the crawl's own bookkeeping.

Failures now go through `_record_failure`, and the remaining writes take the lock. The lock is held only around the dict/set access — never across a fetch or the rate-limit sleep — so throughput is unchanged. `_progress.update()` is called after releasing it, from values snapshotted inside.

### Failed requests were not rate-limited

The sleep only ran on the success path, so a host returning errors was retried at full speed — exactly when adding load is least welcome. Moved into a `finally` so every request is paced.

### `task_done()` could still be skipped

It was the last statement in the `finally`, so anything raising above it — `progress.update()` with a stale task — would skip it and re-hang `crawl()`, the exact failure #27 fixed. I hit this for real when a test passed a `TaskID` from a different `Progress`; the worker died and `queue.join()` blocked forever. A nested `finally` now makes `task_done()` unconditional.

### Malformed PyPI payloads escaped the version lookup

`fetch_package_version` and `_fetch_latest_cpython_version` caught only `URLError`, so bad JSON or an unexpected shape escaped as `JSONDecodeError`, `KeyError`, `TypeError`, or `InvalidVersion`. #28's per-package guard already stops those from aborting the run, but catching them here gives the accurate message and keeps the intent local.

### `Retry-After` is now honoured

429 and 5xx responses often say how long to wait; we ignored it and used our own backoff. Now honoured, clamped to 5 minutes so a large value cannot park a worker — and #27's attempt budget still bounds the total wait.

Also drops the `hasattr(e, "code")` guard, since `HTTPError` always has `.code`.

## Testing

`pytest` (6 passed), `ruff check`/`format`, and `ty` are clean.

Checked against the real classes with mocked I/O: a failed fetch still sleeps for the configured interval; 3200 concurrent `_record_failure`/`_seen_urls` writes across 8 threads all land; a 60-page 8-thread crawl finishes with consistent `seen`/`crawled` counts, no failures and no leaked threads, repeated over 5 trials with a deadlock watchdog; the four malformed-PyPI shapes each return `None` rather than raising; and `Retry-After` parses as seconds, as an HTTP-date, and rejects garbage, with `60` honoured as 60s and `99999` clamped to 300s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015w1f6VC6qKvkL7YQw4FCLy

---
_Generated by [Claude Code](https://claude.ai/code/session_015w1f6VC6qKvkL7YQw4FCLy)_